### PR TITLE
Fix TravisCI by update of ubuntu version to 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
   - '2.7'
 
 
-# Build on Ubuntu 14.04 .
-dist: trusty
+# Build on Ubuntu 18.04 .
+dist: bionic
 
 # Use the full VM to get all packages.
 sudo: true

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -32,10 +32,10 @@ The flasher source code is hosted on GitHub: https://github.com/muhkuh-sys/org.m
 
 Issues are collected here: https://github.com/muhkuh-sys/org.muhkuh.tools-flasher/issues
 
-Each push to the GitHub repository triggers a build on TravisCI using a Ubuntu 12.04 64bit VM: https://travis-ci.org/muhkuh-sys/org.muhkuh.tools-flasher . Another build is triggered on AppVeyor running on 32bit and 64bit Windows: https://ci.appveyor.com/project/docbacardi/org-muhkuh-tools-flasher .
+Each push to the GitHub repository triggers a build on TravisCI using a Ubuntu 18.04 64bit VM: https://travis-ci.org/muhkuh-sys/org.muhkuh.tools-flasher . Another build is triggered on AppVeyor running on 32bit and 64bit Windows: https://ci.appveyor.com/project/docbacardi/org-muhkuh-tools-flasher .
 Each push to the GitHub repository triggers a build on these services:
 
- * TravisCI using a Ubuntu 12.04 64bit VM: https://travis-ci.org/muhkuh-sys/org.muhkuh.tools-flasher
+ * TravisCI using a Ubuntu 18.04 64bit VM: https://travis-ci.org/muhkuh-sys/org.muhkuh.tools-flasher
  * AppVeyor running on 32bit and 64bit Windows: https://ci.appveyor.com/project/docbacardi/org-muhkuh-tools-flasher
  * circleci running on Ubuntu 12.04 64bit VM: https://circleci.com/gh/muhkuh-sys/org.muhkuh.tools-flasher
 


### PR DESCRIPTION
I saw that the Linux build on CI do not work anymore.
The main problem is that [lua 5.1.0.8 build artifacts](https://github.com/muhkuh-sys/org.lua-lua/releases/tag/v5.1.5.8) are not present for trusty  (14.04). Only artifacts for ubuntu 16.04 and higher are available.

This modification replaces the old ubuntu distribution by a newer version (18.04 LTS) and fix the documentation.
The update to 20.04 did not work, dependencies contain release artifacts for ubuntu 20.04.