### PR TITLE
Dev wfp backup

### DIFF
--- a/lua/lua/wfp_control.lua
+++ b/lua/lua/wfp_control.lua
@@ -363,7 +363,16 @@ function WfpControl.__parseCfg_StartElement(tParser, strName, atAttributes)
         aLxpAttr.tResult = nil
         aLxpAttr.tLog.error('Error in line %d, col %d: attribute "offset" is no number: "%s".', iPosLine, iPosColumn, strOffset)
       end
-
+      local strSize = atAttributes["size"]
+      local ulSize
+      if strSize == nil or strSize == "" then
+          -- No size specified.
+          -- aLxpAttr.tResult = nil
+          --aLxpAttr.tLog.error('Error in line %d, col %d: attribute "size" is not set.', iPosLine, iPosColumn)
+      else
+          ulSize = tonumber(strSize)
+        
+      end
       local strCondition = atAttributes['condition']
       if strCondition==nil then
         strCondition = ''
@@ -372,6 +381,7 @@ function WfpControl.__parseCfg_StartElement(tParser, strName, atAttributes)
       local tData = {}
       tData.strType = "Data"
       tData.strFile = strFile
+      tData.ulSize = ulSize
       tData.ulOffset = ulOffset
       tData.strCondition = strCondition
 

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -185,8 +185,12 @@ end
 function backup(tArgs, tLog, tWfpControl, tFlasher)
 	--create a backup for all flash areas in netX
 	--read the flash areas and save the images to reinstall them later
-	--Steps: read the control file, detect the exisiting flashes, read the offset and size for each area inside the flash,copy the contents to different bin files
-	--
+	--Steps:
+		-- read the control file
+		--detect the exisiting flashes
+		-- read the offset and size for each area inside the flash
+		--copy the contents to different bin files
+		--copy xml file
     
   
     local ulSize
@@ -300,7 +304,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                     ulSize = tData.ulSize
 
                                     tLog.info(
-                                        'create backup for Data area 0x%08x-0x%08x ********************************************** ".',
+                                        'create backup for Data area 0x%08x-0x%08x  ".',
                                         ulOffset,
                                         ulOffset + ulSize
                                     )
@@ -313,11 +317,11 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                     if strData == nil then
                                         fOk = false
                                         strMsg = strMsg or "Error while reading"
+                                    else
+                                        -- save the read area  to the output file (write binary)
+                                        local fileName = DestinationFolder .. "/" .. strFile
+                                        pl.utils.writefile(fileName, strData, false)
                                     end
-                                    -- TODO: we don't have anything to write if the read area failed -> only write if readArea worked
-                                    local fileName = DestinationFolder .. "/" .. strFile
-                                    -- save the read area  to the output file (write binary)
-                                    pl.utils.writefile(fileName, strData, false)
                                 elseif tData.strType == "Erase" then
                                     tLog.info("ignore Erase areas with Read function")
                                 end
@@ -330,8 +334,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
         if fOk==true then
             --copy xml_file from target to a destination
             local strDataxml = pl.utils.readfile(tArgs.strWfpControlFile, false)
-            -- TODO: remove prints that were used for debugging
-            print(strDataxml, "*********************************")
+           
             local fWriteOk = pl.utils.writefile(DestinationXml, strDataxml, false)
             if fWriteOk == true then
                 tLog.info("Xml file copied")

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -428,7 +428,9 @@ atName2Bus = {
 local tWfpControl = wfp_control(tLogWriterFilter)
 
 local fOk = true
-
+if tArgs.fCommandBackupSelected == true then
+    fOk = backup(tArgs, tLog)
+end
 if tArgs.fCommandFlashSelected == true or tArgs.fCommandVerifySelected then
     -- Read the control file from the WFP archive.
     tLog.debug('Using WFP archive "%s".', tArgs.strWfpArchiveFile)

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -358,6 +358,23 @@ tParserCommandVerify:option('-v --verbose'):description(string.format('Set the v
 tParserCommandVerify:option('-p --plugin_name'):description("plugin name"):target('strPluginName')
 tParserCommandVerify:option('-t --plugin_type'):description("plugin type"):target('strPluginType')
 
+-- Add the "Backup" command and all its options.
+local tParserCommandBackup =
+    tParser:command("backup b", "backup the contents of the WFP."):target("fCommandBackupSelected")
+tParserCommandBackup:argument("xml", "The XML control file."):target("strWfpControlFile")
+tParserCommandBackup:argument("backup_path", "The destination path to create the backup."):target("strBackupPath")
+tParserCommandBackup:option("-v --verbose"):description(
+    string.format(
+        "Set the verbosity level to LEVEL. Possible values for LEVEL are %s.",
+        table.concat(atLogLevels, ", ")
+    )
+):argname("<LEVEL>"):default("debug"):target("strLogLevel")
+tParserCommandBackup:option("-p --plugin_name"):description("plugin name"):target("strPluginName")
+tParserCommandBackup:option('-t --plugin_type'):description("plugin type"):target('strPluginType')
+tParserCommandBackup:flag("-o --overwrite"):description(
+    "Overwrite an existing folder. The default is to do nothing if the target folder already exists."
+):default(false):target("fOverwrite")
+
 
 -- Add the "list" command and all its options.
 local tParserCommandList = tParser:command('list l', 'List the contents of the WFP.'):target('fCommandListSelected')

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -183,14 +183,14 @@ function printArgs(tArgs, tLog)
 end
 
 function backup(tArgs, tLog, tWfpControl, tFlasher)
-	--create a backup for all flash areas in netX
-	--read the flash areas and save the images to reinstall them later
-	--Steps:
+	-- create a backup for all flash areas in netX
+	-- read the flash areas and save the images to reinstall them later
+	-- Steps:
 		-- read the control file
-		--detect the exisiting flashes
+		-- detect the exisiting flashes
 		-- read the offset and size for each area inside the flash
-		--copy the contents to different bin files
-		--copy xml file
+		-- copy the contents to different bin files
+		-- copy xml file
     
   
     local ulSize
@@ -199,8 +199,8 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
     local DestinationXml = DestinationFolder .. "/wfp.xml"
 
     local fOk = true --be optimistic
-	--overwrite :
-	--check if the directory exists
+	-- overwrite :
+	-- check if the directory exists
 	-- if the overwrite parameter is given then delete the directory otherwise throw an error
     if pl.path.exists(DestinationFolder) == DestinationFolder then
         if tArgs.fOverwrite ~= true then
@@ -217,8 +217,6 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
             end
         end
     end
-    -- TODO: switch the order of creating a folder and reading the control file -> no need to create a folder if the XML is not readable
-    -- TODO: OR delete DestinationFolder is the result of the backup function is False in the end
     if fOk == true then
         pl.path.mkdir(DestinationFolder)
         -- TODO: change this print to a more user friendly one including the path where a folder was created
@@ -240,6 +238,8 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                 tPlugin, strError = getPlugin(tArgs.strPluginName, tArgs.strPluginType)
                 if tPlugin then
                     tPlugin:Connect()
+				else
+					tLog.error(strError)
                 end
             end
 
@@ -290,8 +290,6 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                         break
                                     end
 
-                                    ulSize = tData.ulSize
-
                                     local strFile
                                     if tWfpControl:getHasSubdirs() == true then
                                         tLog.info("WFP archive uses subdirs.")
@@ -304,7 +302,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                     ulSize = tData.ulSize
 
                                     tLog.info(
-                                        'create backup for Data area 0x%08x-0x%08x  ".',
+                                        'read data from area 0x%08x-0x%08x  ".',
                                         ulOffset,
                                         ulOffset + ulSize
                                     )

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -260,9 +260,10 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                         tLog.debug("Processing bus: %s, unit: %d, chip select: %d", strBusName, ulUnit, ulChipSelect)
 
                         -- Detect the device.
-                        fOk = tFlasher.detect(tPlugin, aAttr, tBus, ulUnit, ulChipSelect) --detect whether the flash i have selected is existed inside the hardware
+                        local fDetectOk
+                        fDetectOk = tFlasher.detect(tPlugin, aAttr, tBus, ulUnit, ulChipSelect) --detect whether the flash i have selected is existed inside the hardware
 
-                        if fOk ~= true then
+                        if fDetectOk ~= true then
                             tLog.error("Failed to detect the device!")
                             fOk = false
                             break
@@ -273,7 +274,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                             if tData.strType == "Data" then
                                 print("data**********************************************")
                                 if (tData.ulSize) == nil then
-                                    tLog.error("Size is not existed")
+                                    tLog.error("Size attribute is missing")
                                     fOk = false
                                     break
                                 end
@@ -315,24 +316,27 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                 pl.utils.writefile(fileName, strData, false)
                                 print("DoneWrite**********************************************")
                             elseif tData.strType == "Erase" then
-                                tLog.info("ignor Erase areas with Read function")
+                                tLog.info("ignore Erase areas with Read function")
                             end
                         end
                     end
                 end
-
-                --copy xml_file from target to a destination
-                local strDataxml = pl.utils.readfile(tArgs.strWfpControlFile, false)
-                print(strDataxml, "*********************************")
-                local fOk = pl.utils.writefile(DestinationXml, strDataxml, false)
-                if fOk == true then
-                    tLog.info("Xml file copied")
-                end
             end
+        end
+    end
+    if fOk==true then
+        --copy xml_file from target to a destination
+        local strDataxml = pl.utils.readfile(tArgs.strWfpControlFile, false)
+        print(strDataxml, "*********************************")
+        local fOk = pl.utils.writefile(DestinationXml, strDataxml, false)
+        if fOk == true then
+            tLog.info("Xml file copied")
         end
     end
     return fOk
 end
+
+
 
 local tParser = argparse('wfp', 'Flash, list and create WFP packages.'):command_target("strSubcommand")
 

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -183,16 +183,18 @@ function printArgs(tArgs, tLog)
 end
 
 function backup(tArgs, tLog, tWfpControl, tFlasher)
+    -- TODO: add function description for backup function
+    -- TODO: - what does this function achieve?
+    -- TODO: - which are the steps in the process
   
     local ulSize
-    -- local ulOffset = tData.ulOffset
     local ulOffset
     local DestinationFolder = tArgs.strBackupPath
     local DestinationXml = DestinationFolder .. "/wfp.xml"
-    --create a directory if it is not existed
 
-    --overwrite
     local fOk = true --be optimistic
+
+    -- TODO: describe the how the overwrite works
     if pl.path.exists(DestinationFolder) == DestinationFolder then
         if tArgs.fOverwrite ~= true then
             tLog.error(
@@ -208,9 +210,11 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
             end
         end
     end
+    -- TODO: switch the order of creating a folder and reading the control file -> no need to create a folder if the XML is not readable
+    -- TODO: OR delete DestinationFolder is the result of the backup function is False in the end
     if fOk == true then
-        -- os.execute("mkdir " .. DestinationFolder)
         pl.path.mkdir(DestinationFolder)
+        -- TODO: change this print to a more user friendly one including the path where a folder was created
         print("Folder created************************************")
         local txmlResult = tWfpControl:openXml(tArgs.strWfpControlFile)
 
@@ -218,6 +222,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
             fOk = false
         end
     end
+
     if fOk == true then
         -- Select a plugin and connect to the netX.
         local tPlugin
@@ -270,8 +275,9 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                         end
 
                         for ulDataIdx, tData in ipairs(tTargetFlash.atData) do
-                            -- Is this an data area?
+                            -- Is this a data area?
                             if tData.strType == "Data" then
+                                -- TODO: remove prints that were used for debugging
                                 print("data**********************************************")
                                 if (tData.ulSize) == nil then
                                     tLog.error("Size attribute is missing")
@@ -280,7 +286,7 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                 end
 
                                 ulSize = tData.ulSize
-
+                                -- TODO: remove prints that were used for debugging
                                 print("the size is:******************", ulSize)
 
                                 local strFile
@@ -299,9 +305,11 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                     ulOffset,
                                     ulOffset + ulSize
                                 )
+
                                 -- continue with reading the selected area
 
                                 -- read
+                                -- TODO: remove prints that were used for debugging
                                 print("start reading**********************************************")
 
                                 strData, strMsg = tFlasher.readArea(tPlugin, aAttr, ulOffset, ulSize)
@@ -310,10 +318,11 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
                                     fOk = false
                                     strMsg = strMsg or "Error while reading"
                                 end
-
+                                -- TODO: we don't have anything to write if the read area failed -> only write if readArea worked
                                 local fileName = DestinationFolder .. "/" .. strFile
                                 -- save the read area  to the output file (write binary)
                                 pl.utils.writefile(fileName, strData, false)
+                                -- TODO: remove prints that were used for debugging
                                 print("DoneWrite**********************************************")
                             elseif tData.strType == "Erase" then
                                 tLog.info("ignore Erase areas with Read function")
@@ -327,12 +336,14 @@ function backup(tArgs, tLog, tWfpControl, tFlasher)
     if fOk==true then
         --copy xml_file from target to a destination
         local strDataxml = pl.utils.readfile(tArgs.strWfpControlFile, false)
+        -- TODO: remove prints that were used for debugging
         print(strDataxml, "*********************************")
         local fOk = pl.utils.writefile(DestinationXml, strDataxml, false)
         if fOk == true then
             tLog.info("Xml file copied")
         end
     end
+    -- TODO: add second return value DestinationXml. This can be used later for packing the wfp archive
     return fOk
 end
 
@@ -435,7 +446,7 @@ local fOk = true
 if tArgs.fCommandBackupSelected == true then
     fOk =  backup(tArgs, tLog, tWfpControl, tFlasher)
 
-end
+end -- TODO: should be elseif not end if
 if tArgs.fCommandFlashSelected == true or tArgs.fCommandVerifySelected then
     -- Read the control file from the WFP archive.
     tLog.debug('Using WFP archive "%s".', tArgs.strWfpArchiveFile)
@@ -694,6 +705,7 @@ elseif tArgs.fCommandListSelected == true then
         end
     end
 elseif tArgs.fCommandPackSelected == true then
+    -- TODO: move the pack command into a function
     local archive = require 'archive'
 
     -- Does the archive already exist?

--- a/lua/wfp.lua
+++ b/lua/wfp.lua
@@ -182,8 +182,8 @@ function printArgs(tArgs, tLog)
     print("")
 end
 
-function backup(tArgs, tLog)
-    -- Create the WFP controller.
+function backup(tArgs, tLog, tWfpControl, tFlasher)
+  
     local ulSize
     -- local ulOffset = tData.ulOffset
     local ulOffset
@@ -429,7 +429,8 @@ local tWfpControl = wfp_control(tLogWriterFilter)
 
 local fOk = true
 if tArgs.fCommandBackupSelected == true then
-    fOk = backup(tArgs, tLog)
+    fOk =  backup(tArgs, tLog, tWfpControl, tFlasher)
+
 end
 if tArgs.fCommandFlashSelected == true or tArgs.fCommandVerifySelected then
     -- Read the control file from the WFP archive.


### PR DESCRIPTION
New read function implemented (first trial version)

The first version of the new 'read' command can:

- read a wfp-control-XML 
- parse every <Data> chunk for the selected target netX
- read the content for every Data chunk from the netX (only uses the 'size' and 'offset' attributes of the data chunk )
- create an output folder and store all the read content into binaries
- copy the input XML to the output folder