### PR TITLE
NXTFLASHER-904 fixed flasher for smart_erase and erase_block_size tests

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -673,6 +673,8 @@ static unsigned long getFlashSize(const DEVICE_DESCRIPTION_T *ptDeviceDescriptio
 	unsigned long long ulFlashSize = getActualFlashSize(ptDeviceDescription);
 
 	// Detect SD-cards larger than 4 GiB and treat them as 4 GiB SD-cards
+	// Assumption: No SD Card has exactly 0xffffffff bytes, there are always some defects
+	// Therefore 0xffffffff can be used for limitation detection
 #ifdef CFG_INCLUDE_SDIO
 	if (ptDeviceDescription->tSourceTyp == BUS_SDIO && ulFlashSize > 0xffffffffU)
 	{
@@ -687,7 +689,7 @@ static unsigned long getFlashSize(const DEVICE_DESCRIPTION_T *ptDeviceDescriptio
 static NETX_CONSOLEAPP_RESULT_T opMode_getActualFlashSize(tFlasherInputParameter *ptAppParams){
 	CMD_PARAMETER_GETFLASHSIZE_T *ptParameter;
 
-	/* Get a shortcut to the parameters and save them. */
+	// Get a shortcut to the parameters
 	ptParameter = &(ptAppParams->uParameter.tGetFlashSize);
 	ptParameter->ullActualFlashSize = getActualFlashSize(ptParameter->ptDeviceDescription);
 	ptParameter->ulSupportedFlashSize = getFlashSize(ptParameter->ptDeviceDescription);

--- a/src/main.c
+++ b/src/main.c
@@ -631,6 +631,7 @@ static unsigned long long getActualFlashSize(const DEVICE_DESCRIPTION_T *ptDevic
 #endif
 
 	case BUS_SPI:
+		uprintf("erase block size: 0x%08x\n", ptDeviceDescription->uInfo.tSpiInfo.ulSectorSize);
 		ullFlashSize = ptDeviceDescription->uInfo.tSpiInfo.tAttributes.ulSize;
 		break;
 
@@ -642,6 +643,7 @@ static unsigned long long getActualFlashSize(const DEVICE_DESCRIPTION_T *ptDevic
 			break;
 
 		case INTERNAL_FLASH_TYPE_MAZ_V0:
+			uprintf("erase block size: 0x%08x\n", 0x1000);
 			ullFlashSize = ptDeviceDescription->uInfo.tInternalFlashInfo.uAttributes.tMazV0.ulSizeInBytes;
 			break;
 		}

--- a/templates/flasher.lua
+++ b/templates/flasher.lua
@@ -614,22 +614,22 @@ end
 function M.detectAndCheckSizeLimit(tPlugin, aAttr, ...)
 	local fOk = M.detect(tPlugin, aAttr, ...)
 	local strMsg
-	local ulDeviceSize, ulActualDeviceSize
+	local ulDeviceSize, ullActualDeviceSize
 
 	if fOk ~= true then
 		fOk = false
 		strMsg = "Failed to detect the device!"
 	else
-		ulActualDeviceSize, ulDeviceSize = M.getActualFlashSize(tPlugin, aAttr)
+		ullActualDeviceSize, ulDeviceSize = M.getActualFlashSize(tPlugin, aAttr)
 		if ulDeviceSize == nil then
 			fOk = false
 			strMsg = "Failed to get the device size!"
 
 		-- If the device size is >= 4GiB, the SDIO driver returns size 0xffffffff.
 		elseif ulDeviceSize == 0xffffffff then
-			fOk = true
-			print("Warning: Device with size > 2^32 Bytes detected. Will be treated as 4 GiB device!")
-			print(string.format("Size of Device: %u Bytes, will use first %u Bytes", ulActualDeviceSize, ulDeviceSize))
+				fOk = true
+				print("Warning: Device with size > 2^32 Bytes detected. Will be treated as 4 GiB device!")
+				print(string.format("Size of Device: %u Bytes, will use first %u Bytes", ullActualDeviceSize, ulDeviceSize))
 		end
 	end
 


### PR DESCRIPTION
Add output for erase block size in getActualDeviceSize since it is expected by tests/users

small cosmetic changes