### PR TITLE
[build] Fix incorrect version in start_mi version configuration

### DIFF
--- a/lua/lua/helper_files.lua
+++ b/lua/lua/helper_files.lua
@@ -102,7 +102,7 @@ local atHelperFileVersions = {
     {
         key = "start_mi",
         filename = "hboot_start_mi_netx90_com_intram.bin",
-        version = "Ver:GITv2.5.5-0-g5eca7e77a4b5:reV",
+        version = "Ver:GITv2.5.5-1-g5eca7e77a4b5:reV",
         version_offset = 0x0454
     },
 


### PR DESCRIPTION
When running detect_netx, an error message was printed because the start_mi version did not match an expected version.
The expected version string was only partially changed to a new commit in the past.

The commit hash belongs to a commit that is one commit behind the tag "v2.5.5", so it is "v2.2.5-1".