### PR TITLE
[NXTFLASHER-912] Improve CI + automated artifact naming, fix broken start_mi copy command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,15 @@
 name: CI Build
 
 # Specify when to run the CI Build
-# Note: Running on pull requests does not work since pull request pipelines run in detached-head-state.
 on:
+  # Run when a tag is pushed (set)
   push:
     tags:
-      - '*' # Any tag is pushed
-    branches:
-      - "dev_v*.*.*" # Any dev branch
+      - '*' # Accept any tag name
+
+  # Run when a pull request is opened, reopened or a new change is added to it
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -86,14 +88,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        # Checkout all submodules recursively
-        submodules: recursive
-
-        # Fetch the full history for working "git describe"
-        fetch-depth: 0
-
-        # Fetch git tags
-        fetch-tags: true
+        
+        submodules: recursive # Checkout all submodules recursively
+        fetch-depth: 0        # Fetch the full history for working "git describe"
+        fetch-tags: true      # Fetch git tags
 
     # Disable git safe directory
     - name: Disable Git safe directory
@@ -107,7 +105,7 @@ jobs:
     - name: Build flasher
       run: python3 build_artifact.py ${{ matrix.platform.distribution-id }} ${{ matrix.platform.distribution-version }} ${{ matrix.platform.cpu-architecture }}
     
-          # Upload the artifact
+    # Upload the artifact
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -117,5 +115,5 @@ jobs:
         # What to upload
         path: flasher-environment/build/artifacts/*
 
-        # Expiration time period in days
-        retention-days: 30
+        # Expiration time period in days (90 is maximum)
+        retention-days: 90

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,57 +1,46 @@
 name: CI Build
 
+# Specify when to run the CI Build
 on:
+  # Run when a tag is pushed (set)
   push:
-    branches: [ master, dev_v2.1.2, dev_NXTFLASHER-*]
     tags:
-    - '*'
+      - '*' # Accept any tag name
+
+  # Run when a pull request is opened or reopened
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
-#  netxfirmware:
-#    runs-on: ubuntu-latest
-#    container: ghcr.io/muhkuh-sys/mbs_ubuntu_2204_x86_64:latest
-#    steps:
-#    - name: Checkout repository
-#      # Use the old checkout v1 here. The newer v2 requires git 2.28 which is not available in the standard distribution.
-#      uses: actions/checkout@v1
-#      with:
-#        submodules: recursive
-#    - name: Disable Git safe directory
-#      run: git config --system --add safe.directory '*'
-#    - name: Build netX firmware
-#      run: python3 mbs/mbs
-#    - name: Upload artifacts
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: targets
-#        path: targets
   build:
-#    needs: netxfirmware
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         platform:
-#        - name: Ubuntu 18.04 x86
-#          image: ghcr.io/muhkuh-sys/mbs_ubuntu_2204_x86_64:latest
-#          distribution-id: ubuntu
-#          distribution-version: "18.04"
-#          cpu-architecture: x86
-#        - name: Ubuntu 18.04 x86_64
-#          image: ghcr.io/muhkuh-sys/mbs_ubuntu_2204_x86_64:latest
-#          distribution-id: ubuntu
-#          distribution-version: "18.04"
-#          cpu-architecture: x86_64
-#        - name: Ubuntu 18.04 arm64
-#          image: ghcr.io/muhkuh-sys/mbs_ubuntu_2204_x86_64:latest
-#          distribution-id: ubuntu
-#          distribution-version: "18.04"
-#          cpu-architecture: arm64
-#        - name: Ubuntu 20.04 x86
-#          image: ghcr.io/muhkuh-sys/mbs_ubuntu_2204_x86_64:latest
-#          distribution-id: ubuntu
-#          distribution-version: "20.04"
-#          cpu-architecture: x86
+        # Ubuntu 18 seems to lack GLIBC_2.28 which is required for upload-artifact@v4.
+        #- name: Ubuntu 18.04 x86
+        #  image: ghcr.io/muhkuh-sys/mbs_ubuntu_1804_x86:latest
+        #  distribution-id: ubuntu
+        #  distribution-version: "18.04"
+        #  cpu-architecture: x86
+        #- name: Ubuntu 18.04 x86_64
+        #  image: ghcr.io/muhkuh-sys/mbs_ubuntu_1804_x86_64:latest
+        #  distribution-id: ubuntu
+        #  distribution-version: "18.04"
+        #  cpu-architecture: x86_64
+        #- name: Ubuntu 18.04 arm64
+        #  image: ghcr.io/muhkuh-sys/mbs_ubuntu_1804_x86_64:latest
+        #  distribution-id: ubuntu
+        #  distribution-version: "18.04"
+        #  cpu-architecture: arm64
+
+        # 32bit linux runners seem to be no longer supported.
+        #- name: Ubuntu 20.04 x86
+        #  image: ghcr.io/muhkuh-sys/mbs_ubuntu_2004_x86:latest
+        #  distribution-id: ubuntu
+        #  distribution-version: "20.04"
+        #  cpu-architecture: x86
         - name: Ubuntu 20.04 x86_64
           image: ghcr.io/muhkuh-sys/mbs_ubuntu_2004_x86_64:latest
           distribution-id: ubuntu
@@ -93,28 +82,42 @@ jobs:
           distribution-version: ""
           cpu-architecture: x86_64
     container: ${{ matrix.platform.image }}
+
     steps:
-    
+    # Checkout the repository
     - name: Checkout repository
-      # Use the old checkout v1 here. The newer v2 requires git 2.28 which is not available in the standard distribution.
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
+        # Checkout all submodules recursively
         submodules: recursive
+
+        # Fetch the full history for working "git describe"
+        fetch-depth: 0
+
+        # Fetch git tags
+        fetch-tags: true
+
+    # Disable git safe directory
     - name: Disable Git safe directory
       run: git config --system --add safe.directory '*'
-#    - name: Download firmware
-#      # Use the old download-artifact v1 here. The newer v2 does not work with 32bit containers.
-#      uses: actions/download-artifact@v1
-#      with:
-#        name: targets
+
+    # Install pip and use it to install gitpython
     - name: Install pip and get dependencies for build script
-      run: apt update && apt install -y python3-pip && python3 -m pip install gitpython
+      run:  apt update && apt install -y python3-pip && python3 -m pip install gitpython
+    
+    # Run the actual build process
     - name: Build flasher
-      run: python3 build_artifact.py -m ${{ matrix.platform.distribution-id }} ${{ matrix.platform.distribution-version }} ${{ matrix.platform.cpu-architecture }}
+      run: python3 build_artifact.py ${{ matrix.platform.distribution-id }} ${{ matrix.platform.distribution-version }} ${{ matrix.platform.cpu-architecture }}
+    
+          # Upload the artifact
     - name: Upload artifacts
-      # Use the old upload-artifact v1 here. The newer v2 does not work with 32bit containers.
-      # Use v4 but uncomment four platforms that failed the run (until fixed) -> 32 bit verions don't work with v4
       uses: actions/upload-artifact@v4
       with:
+        # Name of the artifact to upload.
         name: artifacts_${{ matrix.platform.distribution-id }}${{ matrix.platform.distribution-version }}_${{ matrix.platform.cpu-architecture }}
-        path: flasher-environment/build/artifacts
+
+        # What to upload
+        path: flasher-environment/build/artifacts/*
+
+        # Expiration time period in days
+        retention-days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,13 @@
 name: CI Build
 
 # Specify when to run the CI Build
+# Note: Running on pull requests does not work since pull request pipelines run in detached-head-state.
 on:
-  # Run when a tag is pushed (set)
   push:
     tags:
-      - '*' # Accept any tag name
-
-  # Run when a pull request is opened or reopened
-  pull_request:
-    types: [opened, reopened]
+      - '*' # Any tag is pushed
+    branches:
+      - "dev_v*.*.*" # Any dev branch
 
 jobs:
   build:

--- a/SConstruct
+++ b/SConstruct
@@ -257,11 +257,9 @@ strBuildTime = tBuildTime.strftime("%Y-%B-%d-T%H:%M")
 tDict = {'BUILD_TIME': strBuildTime} 
 
 # Set the dev ending
-# dev-branch:      "devX"
-# release-branch:  ""
-# everything else: branch name
+# dev-branch: "devX" or master-branch ""
 repoManager = gitVersionManager(".")
-if repoManager.onDevBranch() or repoManager.onReleaseBranch():
+if repoManager.onDevBranch() or repoManager.onMasterBranch():
     tDict['BUILD_TYPE'] = repoManager.getDevEnding()
 else:
     tDict['BUILD_TYPE'] = "-" + repoManager.getCurrentBranchName()

--- a/build_artifact.py
+++ b/build_artifact.py
@@ -324,19 +324,18 @@ for strPath in astrFolders:
 #
 
 # Get the flasher repo and the current branch name
-repoManager = gitVersionManager(strCfg_projectFolder, "flasher")
+repoManager = gitVersionManager(strCfg_projectFolder)
 if flags["gitTagRequested"]:
     repoManager.createDevTag()
 
 # Set the artifact name
 strMbsProjectVersion = repoManager.getFullVersionString()
-
+ 
 # Create the name of the platform following the hilscher naming conventions
 translator = dict(x86="x86", x86_64="x64", windows="Windows", ubuntu="Ubuntu", arm64="arm64", armhf="armhf",
                   riscv64="riscv64")
 strPlatform = tPlatform["distribution_version"] or ""
-strArtifactPlatform = translator[tPlatform["distribution_id"]] + strPlatform + "-" + translator[
-    tPlatform["cpu_architecture"]]
+strArtifactPlatform = translator[tPlatform["distribution_id"]] + strPlatform + "-" + translator[tPlatform["cpu_architecture"]]
 
 # Write the flasher version to the xml file (XML parser would delete comments in file)
 with open(os.path.join(strCfg_projectFolder, 'setup.xml'), "r+") as tSetupXmlFile:
@@ -370,7 +369,7 @@ subprocess.check_call(
 # Generate the output folder name out of the romloader git tags
 print("load romloader files")
 strRomloaderFolder = os.path.join(strCfg_projectFolder, "flasher-environment", "org.muhkuh.lua-romloader")
-romloaderRepoManager = gitVersionManager(strRomloaderFolder, "romloader")
+romloaderRepoManager = gitVersionManager(strRomloaderFolder)
 romloaderArtifactName = "montest_" + romloaderRepoManager.getFullVersionString()
 print(f"romloader artifact: {romloaderArtifactName}")
 

--- a/flasher-environment/CMakeLists.txt
+++ b/flasher-environment/CMakeLists.txt
@@ -93,7 +93,11 @@ SET(TARGET_LUA TARGET_lua54)
 SET(INSTALL_DIR_LUA_MODULES ${FLASHER_PACKAGE_DIR}/lua_plugins)
 ADD_SUBDIRECTORY(org.muhkuh.lua-romloader/plugins)
 
+# Copy hboot_start_mi_netx90_com_intram.bin to the archive
+INSTALL(FILES org.muhkuh.lua-romloader/targets/plugins/romloader/machine_interface/start_mi/hboot_start_mi_netx90_com_intram.bin
+    DESTINATION ${FLASHER_PACKAGE_DIR}/netx/hboot/unsigned/netx90)
 
+	
 #----------------------------------------------------------------------------
 #
 # Build a package for the selected platform.

--- a/gitVersionManager.py
+++ b/gitVersionManager.py
@@ -5,76 +5,184 @@ try:
 except:
     raise ImportError("Module gitpython missing, install using \"pip install gitpython\"")
 
-# Class for managing git tags and getting version strings in the flasher and romloader repo
 class gitVersionManager:
+    """Class for managing git tags and getting version strings in the flasher and romloader repository."""
+
+    # Regex for the version formats
     versionFormat = r"v\d+\.\d+\.\d+"
     devBranchFormat = r"^dev_v\d+\.\d+\.\d+$"
     devTagFormat = r"v\d+\.\d+\.\d+-dev\d+"
     releaseTagFormat = versionFormat
-    releaseBranchNames = ["master", "HEAD"]
 
+    def __init__(self, strRepoPath):
+        """
+        Create a gitVersionManager Object
 
-    # Creates a gitVersionManager Object
-    #
-    # strRepoPath = path the current repo is in (use "/" for dirs, "." for current dir)
-    def __init__(self, strRepoPath, repo_nickname=""):
+        :param strRepoPath: path the current repo is in (use "/" for directories, "." for current directory)
+        """
         self.repo = git.Repo(strRepoPath)
-        self.repo_nickname = repo_nickname
 
-
-    # Gets the branch the repository is currently on.
-    #
-    # Detached Head state is tricky. Will return the first found branch the current commit is on.
-    def getCurrentBranch(self):
-        # Try to get the current branch, if the head is detached, look for a branch containing the current commit
-        currentCommit = self.repo.head.commit
-        if self.repo.head.is_detached:
-            for branch in self.repo.remotes["origin"].refs:
-                if self.repo.is_ancestor(currentCommit, branch.commit)\
-                    or currentCommit == branch.commit:
-                    return branch
-        else:
-            return self.repo.active_branch
-
-
-    # Gets the current branch name
-    def getCurrentBranchName(self):
-        branch = self.getCurrentBranch()
-        # Remove "origin/" if present
-        if "/" in branch.name:
-            return str.split(branch.name, "/")[-1]
-        print(f"({self.repo_nickname})current branch name: {branch.name}")
-        return branch.name
-
-
-    # Checks if current branch is a dev branch (matches the pattern "dev_vX.Y.Z", e.g. dev_v2.1.0)
     def onDevBranch(self):
+        """
+        Check if current branch is a dev branch (matches the pattern "dev_vX.Y.Z", e.g. dev_v2.1.0)
+        
+        :return: True if the current branch is a dev branch (e.g. dev_v2.1.0).
+        """
         return bool(re.match(self.devBranchFormat, self.getCurrentBranchName()))
 
 
-    # Checks if the current branch is the release branch
-    def onReleaseBranch(self):
-        current_branch_name = self.getCurrentBranchName()
-        return current_branch_name in self.releaseBranchNames
+    def onMasterBranch(self):
+        """
+        Check if the current branch is the master branch
+        
+        :return: True if the current branch is the master branch.
+        """
+        return self.getCurrentBranchName() == "master"
+    
+    def getAllBranches(self):
+        """
+        Get all avalilable branches.
 
-    # Gets the last tag from "git describe"-output
-    #
-    # Note that tags will be inherited when merging.
-    # When merging to release branch, create a release version tag ("vA.B.C")
-    # Only works with:
-    # dev-tags:     "vA.B.C-devD"
-    # release-tags: "vA.B.C"
-    # Aborts if other tag is found or branch-tag combination is invalid.
+        Combine local and remote branch lists avoiding duplicates.
+
+        :return: List with all available branch objects.
+        """
+        # Get all local branches
+        branches = list(self.repo.branches)
+
+        # Get all remote branches
+        for ref in self.repo.remotes["origin"].refs:
+            if ref.name.startswith("origin/"):
+                # Avoid duplicates (local and remote)
+                remoteBranchName = ref.name.replace("origin/", "")
+                if all(knownBranch.name != remoteBranchName for knownBranch in branches):
+                    branches.append(ref)
+        return branches
+    
+    def findNearestBranch(self):
+        """
+        Search for the nearest branch in the history (looks forward in time)
+
+        :return: The branch object of the nearest branch.
+        """
+        currentCommit = self.repo.head.commit
+
+        # Get the branch that is ahead the closest
+        nearest = 0
+        nearestBranch = None
+        for branch in self.getAllBranches():
+            # Avoid "origin/HEAD"
+            if branch.name == "origin/HEAD":
+                continue
+
+            # Check if the branch is ahead of the current commit
+            if self.repo.is_ancestor(currentCommit, branch.commit):
+                # Count the number of commits the branch is ahead
+                checkCommit = branch.commit
+                numAhead = 0
+                while checkCommit != currentCommit:
+                    numAhead += 1
+
+                    # Get the right parent commit
+                    for parentCommit in checkCommit.parents:
+                        # If the current commit is an ancestor of the parent, they belong to one branch.
+                        # Otherwise, the parent comes from a merge. Do not go that way.
+                        if self.repo.is_ancestor(currentCommit, parentCommit):
+                            checkCommit = parentCommit
+                            break
+
+                # Check if the branch is closer than the last nearest branch
+                if nearestBranch == None or nearest > numAhead:
+                    nearest = numAhead
+                    nearestBranch = branch
+
+        # After checking all branches, return the nearest
+        return nearestBranch
+
+    def getCurrentBranch(self):
+        """
+        Get the branch the repository is currently on.
+
+        Detached Head state requires branch detection:
+            1) Search for a branch the current commit is on
+            2) Search for the nearest branch that is a descendant of the current commit.
+            3) Search for a branch the second parent commit is on
+
+            Finding the branch via the current commit is required when working on submodules.
+            If a submodule is provided as a single commit, it is put in a "detached head state"
+
+            Finding the branch via the second parent commit is required in GitHub CI on Pull Requests.
+            The Pull Request CI run is executed on a merged repository state.
+            The second parent commit is the source commit for merging, the first would be the target.
+
+        :return: The branch object
+        :return: True if currently in a merge request context, otherwise false
+        """
+        currentCommit = self.repo.head.commit
+
+        # If the head is not detached, return the active branch
+        if not self.repo.head.is_detached:
+            print("Use current branch: ", self.repo.active_branch)
+            return self.repo.active_branch, False
+
+        # Check if there is an ahead branch which is an descendant of the current commit.
+        # This is required if a commit which has descendants is used.
+        nearestBranch = self.findNearestBranch()
+        if nearestBranch is not None:
+            print("Found closest branch: ", nearestBranch.name)
+            return nearestBranch, False
+
+        # If no branch was found yet, check the past.
+        # This is required on pull request merge commits in GitHub or in submodules.
+        # Otherwise check if the current commit is a merge commit (more than 1 parent).
+        if len(currentCommit.parents) > 1:
+            # The first parent is the target branchs last commit.
+            # Since the source branch is relevant, use the second.
+            for branch in self.getAllBranches():
+                if currentCommit.parents[1] == branch.commit:
+                    print("Found branch via parent commit: ", branch)
+                    return branch, True
+
+        # If no branch was detected, throw an Exception with some details.
+        errorMsg = "ERROR: Branch could not be detected. "
+        errorMsg += f"Repository: {self.repo.working_dir}; "
+        errorMsg += f"Commit: {currentCommit}"
+        raise Exception(errorMsg)
+
+    def getCurrentBranchName(self):
+        """
+        Get the name of the current branch
+        
+        :return: name of the current branch.
+        """
+        branch, _ = self.getCurrentBranch()
+
+        # Remove "origin/" if present
+        if "/" in branch.name:
+            return str.split(branch.name, "/")[-1]
+        return branch.name
 
     def getLastTag(self):
+        """
+        Get the last tag from "git describe"-output
+    
+        Note that tags will be inherited when merging.
+        When merging to master, create a release version tag ("vA.B.C")
+
+        Only works with:
+        dev-tags:     "vA.B.C-devD"
+        release-tags: "vA.B.C"
+        Will abort if other tag is found or branch-tag combination is invalid.
+        
+        :return: The last git tag object in the current commits history.
+        """
         # Get the git describe output, gitpython has no good way of providing the tag
-        description = self.repo.git.describe()  # e.g. 'v2.1.0-dev13-15-gb39e454' or 'v2.1.0' when directly on tag
-        print(f"({self.repo_nickname})git describe: {description}")
+        description = self.repo.git.describe() # e.g. 'v2.1.0-dev13-15-gb39e454' or 'v2.1.0' when directly on tag
         if re.match(self.devTagFormat, description):
-            assert not self.onReleaseBranch(), "Got dev tag but on release branch - forgot to set release tag?"
+            assert not self.onMasterBranch(), "Got dev tag but on master branch - forgot to set release tag?"
             tagName = re.search(self.devTagFormat, description).group()
         elif re.match(self.releaseTagFormat, description):
-            assert self.onReleaseBranch(), "Got release tag but on dev branch - forgot to set \"dev0\"-tag?"
+            assert self.onMasterBranch(), "Got release tag but on dev branch - forgot to set \"dev0\"-tag?"
             tagName = re.search(self.releaseTagFormat, description).group()
         else:
             tagName = None
@@ -83,37 +191,46 @@ class gitVersionManager:
         for tag in self.repo.tags:
             if tag.name == tagName:
                 return tag
-        sys.exit("Unable to find git tag that matches describe output")
+        raise Exception("Unable to find git tag that matches describe output")
 
-
-    # Gets the dev tag number
-    # 
-    # e.G. v2.1.0-dev13 will result in 13
-    #
-    # tag: tag the number should be parsed of
     def getDevTagNumber(self, tag):
+        """
+        Get the dev tag number, e.G. v2.1.0-dev13 will result in 13
+    
+        :param tag: Tag the number should be parsed of
+        :return: The dev tag number parsed from the dev tag.
+        """
         assert re.match(self.devTagFormat, tag.name)
         return int(re.findall(r'\d+', tag.name)[-1])
 
-
-    # Gets the number of commits made since the tag was set
-    #
-    # tag: the tag to start counting from
     def getCommitsSinceLastTag(self):
+        """
+        Get the number of commits since the last tag was set.
+
+        The format of the tag is specified by getLastTag().
+    
+        :param tag: the tag to start counting from.
+        :return: The number of commits since the last tag.
+        """
         lastTagCommitHash = self.getLastTag()._get_commit().hexsha
         currentCommitHash = self.repo.head.commit.hexsha
-        return int(self.repo.git.rev_list('--count', '--ancestry-path', f'{lastTagCommitHash}..{currentCommitHash}'))
+        return int(self.repo.git.rev_list('--count', f'{lastTagCommitHash}..{currentCommitHash}'))
 
-
-    # Creates a new dev tag with a new number (vA.B.C-devD)
-    # 
-    # Will abort when not on a dev branch (name must be "dev_vA.B.C").
-    # Will abort if there is a tag already set on the current commit.
-    # Requires presence of "dev0"-tag on (first) dev branch commit (create it manually!).
-    # The dev tag number (D) is the previous dev tag number increased by the number of 
-    # commits since the last dev tag was set.
     def createDevTag(self):
-        assert self.onDevBranch(), "Trying to create dev tag outside of dev branch, abort"
+        """
+        Create a new dev tag with a new number in the local repository.
+    
+        Will abort when not on a dev branch (name must be "dev_vA.B.C").
+        Will only set a dev tag if there is not already one set on the current commit.
+        Requires presence of "dev0"-tag on first dev branch commit (create it manually!).
+        The dev tag number is the previous dev tag number increased by the number of commits
+        since the last dev tag was set.
+        
+        :return: The new tag as an object. No need to use it.
+        """
+        if not self.onDevBranch():
+            raise Exception("Trying to create dev tag outside of dev branch, abort")
+        
         lastTag = self.getLastTag()
         lastDevTagNumber= self.getDevTagNumber(lastTag)
         lastTagCommitHash = lastTag._get_commit().hexsha
@@ -121,85 +238,71 @@ class gitVersionManager:
         newTag = None
 
         # Do not set multiple dev tags on a single commit
-        assert lastTagCommitHash != currentCommitHash, "Tag already exists on current commit"
-
-        # Create a new tag increased by the number of commits since last tag and generate the project version string
-        latestDevTagVersion = re.search(self.versionFormat, lastTag.name).group()
-        newDevTagName = latestDevTagVersion + "-dev" + str(lastDevTagNumber + self.getCommitsSinceLastTag())
-
-        # Try to create the git tag on the current commit
-        try:
-            newTag = git.Tag.create(self.repo, newDevTagName, self.repo.head.commit, "Tag created automatically by flasher build process")
-        except:
-            sys.exit(f'Could not create tag \"{newDevTagName}\" on commit \"{currentCommitHash}\"')
-        return newTag
-
-    # Gets the version number of the last tag (e.g. "v2.1.0")
-    #
-    # Aborts if there is no version in the last tag.
-
+        if lastTagCommitHash != currentCommitHash:
+            # Create a new tag increased by the number of commits since last tag and generate project version string
+            latestDevTagVersion = re.search(self.versionFormat, lastTag.name).group()
+            newDevTagName = latestDevTagVersion + "-dev" + str(lastDevTagNumber + self.getCommitsSinceLastTag())
+            try:
+                newTag = git.Tag.create(self.repo, newDevTagName, self.repo.head.commit,
+                                        "Tag created automatically by flasher build process")
+            except:
+                raise Exception(f'Could not create tag \"{newDevTagName}\" on commit \"{currentCommitHash}\"')
+            return newTag
 
     def getVersionNumber(self):
-        last_git_tag_name = self.getLastTag().name
-        print(f"Last git tag name: {last_git_tag_name}")
-        assert re.match(self.versionFormat, last_git_tag_name), "Invalid format of last git tag"
-        return re.search(self.versionFormat, last_git_tag_name).group()
+        """"
+        Get the version number of the previous tag (e.g. "v2.1.0")
+    
+        Aborts if the version can not be parsed.
 
-    # Gets the dev ending
-    #
-    # When on release branch:
-    # ""   when the current commit is the release tag commit
-    # "-X" when there were X commits since the last release tag
-    #
-    # When not on release branch:
-    # "-devA-B+"
-    # A = dev version from tag
-    # B = commits since last tag
-    # + : optional - will appear when the repo is dirty
+        :return: The version number of the last git tag.
+        """
+        assert re.match(self.versionFormat, self.getLastTag().name), "Invalid format of last git tag"
+        return re.search(self.versionFormat, self.getLastTag().name).group()
+
     def getDevEnding(self):
-        if self.onReleaseBranch():
+        """
+        Get the dev ending including commits since the last tag and the "repo-dirty"-"+".
+    
+        Will omit "-devA" when on master branch (release)
+        "-devA-B+"
+        A = dev version from tag
+        B = commits since last tag
+        + : optional - will appear when the repo is dirty
+
+        :return: The dev ending depending on the current branch.
+        """
+        if self.onMasterBranch():
             ending = ""
-            if(self.getCommitsSinceLastTag() > 0):
-                ending += "-" + str(self.getCommitsSinceLastTag())
         else:
             ending = "-dev" + str(self.getDevTagNumber(self.getLastTag()))
-            ending += "-" + str(self.getCommitsSinceLastTag()) 
+
+        # Append the number of commits since the last tag if nonzero
+        commitsSinceLastTag = self.getCommitsSinceLastTag()
+        if commitsSinceLastTag > 0:
+            ending += "-" + str(commitsSinceLastTag) 
+
+        # Add a "+" character if the repository is dirty
+        ending += "+" if self.repo.is_dirty() else ""
         return ending
 
-    # Get the full Version string suitable for the current branch
-    #
-    # dev-branch or release branch: 
-    #  version + dev ending (from getDevEnding())
-    #  vA.B.C-devD-E
-    # 
-    # other (e.g. feature branch):
-    #  version + "-" + branch name + "-g" + short commit hash + repo-dirty-"+"
-    #  vA.B.C-BRANCH-gHASH+
-    # 
-    # A.B.C = flasher version
-    # D = dev tag version
-    # E = commits since last tag (optional)
-    # + : optional - inserted when the repo is dirty
-    # HASH = shortened git hash of the current commit
     def getFullVersionString(self):
+        """
+        Get the full Version string, format:
+    
+        vA.B.C-devD+-E-gHASH
+        A.B.C = flasher version
+        D = dev tag version
+        E = optional - when greater than 0: commits since last tag
+        + : optional - will appear when the repo is dirty
+        HASH = shortened git hash of the current commit (optional when on dev branch or in detached head state)
+
+        :return: The full version string consisting out of version number, dev Ending and the last 7 commit hash chars.
+        """
         name = self.getVersionNumber()
-        print(f"({self.repo_nickname})getFullVersionString: {name}")
-        if self.onDevBranch() or self.onReleaseBranch():
-            name += self.getDevEnding()
-        else:
-            name += "-" + self.getCurrentBranchName()
-            name += "-g" + str(self.repo.head.commit.hexsha)[:7]
-            name += "+" if self.repo.is_dirty() else ""
+        name += self.getDevEnding()
+        
+        # If not on master or dev branch, also append the commit hash
+        if not self.onMasterBranch() and not self.onDevBranch():
+            name += "g" + str(self.repo.head.commit.hexsha)[:7]
         return name
-
-
-if __name__ == '__main__':
-    repoManager = gitVersionManager(".")
-    if repoManager.onDevBranch() or repoManager.onReleaseBranch():
-        build_type = repoManager.getDevEnding()
-    else:
-        build_type = "-" + repoManager.getCurrentBranchName()
-
-    # Set the artifact name
-    strMbsProjectVersion = repoManager.getFullVersionString()
-    print("")

--- a/gitVersionManager.py
+++ b/gitVersionManager.py
@@ -1,5 +1,6 @@
+import os
 import re
-import sys
+
 try:
     import git
 except:
@@ -119,17 +120,18 @@ class gitVersionManager:
         :return: True if currently in a merge request context, otherwise false
         """
         currentCommit = self.repo.head.commit
+        repoName = f"{os.path.basename(self.repo.working_dir)} on commit {currentCommit.hexsha}"
 
         # If the head is not detached, return the active branch
         if not self.repo.head.is_detached:
-            print("Use current branch: ", self.repo.active_branch)
+            print(f"{repoName}: Use current branch: {self.repo.active_branch}")
             return self.repo.active_branch, False
 
         # Check if there is an ahead branch which is an descendant of the current commit.
         # This is required if a commit which has descendants is used.
         nearestBranch = self.findNearestBranch()
         if nearestBranch is not None:
-            print("Found closest branch: ", nearestBranch.name)
+            print(f"{repoName}: Found closest branch: {nearestBranch.name}")
             return nearestBranch, False
 
         # If no branch was found yet, check the past.
@@ -140,7 +142,7 @@ class gitVersionManager:
             # Since the source branch is relevant, use the second.
             for branch in self.getAllBranches():
                 if currentCommit.parents[1] == branch.commit:
-                    print("Found branch via parent commit: ", branch)
+                    print(f"{repoName}: Found branch via parent commit: {branch}")
                     return branch, True
 
         # If no branch was detected, throw an Exception with some details.

--- a/lua/lua/helper_files.lua
+++ b/lua/lua/helper_files.lua
@@ -102,7 +102,7 @@ local atHelperFileVersions = {
     {
         key = "start_mi",
         filename = "hboot_start_mi_netx90_com_intram.bin",
-        version = "Ver:GITv2.5.5-0-g5eca7e77a4b5:reV",
+        version = "Ver:GITv2.5.6-dev0-0-g233ff6a62457:reV",
         version_offset = 0x0454
     },
 

--- a/lua/lua/helper_files.lua
+++ b/lua/lua/helper_files.lua
@@ -95,7 +95,7 @@ local atHelperFileVersions = {
     {   -- Todo: Turn this into a template to insert version automatically.
         key = "flasher_netx90_hboot",
         filename = "flasher_netx90_hboot.bin",
-        version = "GITv2.1.2",
+        version = "GITv2.2.0",
         version_offset = 0x0410
     },
 
@@ -197,10 +197,11 @@ local function checkHelperFileIntern(strDir, strKey, fCheckversion)
 
             if fCheckversion == true then
                 local fOk
+                local strFileVersion = nil
                 if iOffset ~= nil then
                     local iStartOffset = iOffset+1
                     local iEndOffset = iOffset+strVersion:len()
-                    local strFileVersion = strBin:sub(iStartOffset, iEndOffset)
+                    strFileVersion = strBin:sub(iStartOffset, iEndOffset)
                     fOk = ( strFileVersion == strVersion)
                 else
                     local m = strBin:find(strVersion, 1, true)
@@ -213,9 +214,10 @@ local function checkHelperFileIntern(strDir, strKey, fCheckversion)
                 else
                     strBin = nil
                     strMsg = string.format(
-                      "Helper file '%s' does not have the expected version (%s) - ERROR",
+                      "Helper file '%s' does not have the expected version (expected: %s file version: %s)  - ERROR",
                       strKey,
-                      strVersion
+                      strVersion,
+                      strFileVersion
                     )
                     print(strMsg)
                 end

--- a/setup.xml
+++ b/setup.xml
@@ -3,7 +3,7 @@
 
 <muhkuh_buildsystem group="org.muhkuh.tools" module="flasher">
 	<!-- Project version will be automatically overwritten by build_artifact.py-->
-	<project_version>2.1.2</project_version>
+	<project_version>2.2.0</project_version>
 
 	<scons>
 		<group>org.scons</group>


### PR DESCRIPTION
CI: (yml)
- new checkout: v4 istead of v1
- rules when to run (any tag + any pull request (open, reopen, edit))
- comments

Git version manager:
- Improved branch detection
- Fix bugs breaking the naming conventions
- Add pull request merge commit build support
  - getCurrentBranch(): Get the current branch the repository is on
  - findNearestBranch(): Get the next logical branch a commit belongs to
  - getDevEnding(): Generate the dev-Ending as specified in NXTFLASHER-912
- Refactoring
- Adapt occurences of the manager in build scripts to the changes

CMake:
- install command for the file hboot_start_mi_netx90_com_intram.bin moved to flasher (was in romloader previously)
- use relative paths for hboot_start_mi_netx90_com_intram.bin install command

Misc:
- Update version of hboot image
- Update flasher version in config file